### PR TITLE
chore(deps): Downgrade agp from 8.12.0 to 8.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.0"
+agp = "8.11.1"
 kotlin = "2.2.0"
 
 [libraries]


### PR DESCRIPTION
Downgrades agp from 8.10.0 to 8.12.0.
Updates com.android.application from 8.12.0 to 8.11.1

Updates com.android.library from 8.12.0 to 8.11.1

Android Gradle Plugin 8.12.0 is not compatible with KMP