### PR TITLE
feat: Integrate CycloneDX for SBOM generation

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,9 @@ jobs:
         # GITHUB_REF tag comes in the format 'refs/tags/xxx'.
         # Split on '/' and take the 3rd value to get the release name.
         run: |
+          echo "Generating BOM"
+          ./gradlew cyclonedxBom
+          
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
           echo "Github username: ${GITHUB_ACTOR}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.11.1"
+cyclonedx = "2.3.1"
 kotlin = "2.2.0"
 
 [libraries]
@@ -8,6 +9,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
+cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }


### PR DESCRIPTION
This commit introduces CycloneDX to the project for Software Bill of Materials (SBOM) generation.

Key changes:
- Added the `org.cyclonedx.bom` plugin with version `2.3.1`.
- Applied the plugin to all subprojects.
- Configured Maven publications to include the generated `bom.json` as an artifact with the "sbom" classifier.
- Configured CycloneDX tasks to:
    - Include `runtimeClasspath` and `iosArm64CompileKlibraries` configurations.
    - Skip `compileClasspath`, `testCompileClasspath`, and `testRuntimeClasspath` configurations.
- Set the `group` for subprojects to "com.kmpkit".

closes #55 